### PR TITLE
REPL: print \n before quitting

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,8 +24,10 @@ static int repl()
 	while (1)
 	{
 		char* str = l_plat_readline("> ");
-		if (str == NULL)
+		if (str == NULL) {
+			printf("\n");
 			return 1;
+		}
 
 		l_scanner* stream = l_scanner_create_str(str);
 		l_vm_var* v = l_vm_run(vm, l_parse(stream));


### PR DESCRIPTION
This way the command prompt starts on the next line instead of on the same line as "> "